### PR TITLE
docs: improve README and agent guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 ﻿# AGENTS – Development Guidelines for MauiGame
 
-This document describes **how contributors and maintainers should work on MauiGame**.  
-It is intended as an internal playbook for architecture, coding style, and long-term maintenance.
+This document outlines how contributors and maintainers should work on **MauiGame**.
+It serves as an internal playbook for architecture, coding style, and long-term maintenance.
 
 ---
 
@@ -92,16 +92,24 @@ The project is split into 4 parts:
 
 ## 6. Roadmap
 
-- ⬜ Basic rendering (sprites, text)
-- ⬜ Content loading (textures, fonts)
-- ⬜ Fixed timestep loop
-- ⬜ Input handling (multi-touch, keyboard)
-- ⬜ Audio playback
-- ⬜ Scene manager
+- ✅ Basic rendering (sprites, text)
+- ✅ Content loading (textures, fonts)
+- ✅ Fixed timestep loop
+- ✅ Input handling (multi-touch, keyboard)
+- ✅ Audio playback
+- ✅ Scene manager
 - ⬜ Animation system (spritesheets)
 - ⬜ Tilemap loader (Tiled JSON/TMX)
 - ⬜ Particle system
 - ⬜ Physics integration (Box2D/Chipmunk or custom)
+
+---
+
+## 7. Development & Testing
+
+- Use the .NET 9 SDK.
+- Ensure the solution builds with `dotnet build`.
+- Run the `SampleGame` project for manual testing; automated tests are not yet available.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ﻿# MauiGame – Lightweight 2D Game Engine for .NET MAUI
 
-**MauiGame** is a cross-platform 2D game engine for **.NET MAUI**, inspired by MonoGame but designed for modern cross-platform apps with SkiaSharp rendering.
+**MauiGame** is a cross-platform 2D game engine for **.NET MAUI**, inspired by MonoGame but designed for modern cross-platform apps with **SkiaSharp** rendering.
 
 It runs on:
 - Android
@@ -19,6 +19,21 @@ It runs on:
 - 🖱 **Input system** supporting touch, mouse, and keyboard.
 - 🗂 **Scene management** for easy game state transitions.
 - 📜 **Cross-platform**: single codebase, runs everywhere MAUI runs.
+
+---
+
+## 🗺 Roadmap
+
+- [x] Basic rendering (sprites, text)
+- [x] Content loading (textures, fonts)
+- [x] Fixed timestep loop
+- [x] Input handling (multi-touch, keyboard)
+- [x] Audio playback
+- [x] Scene manager
+- [ ] Animation system (spritesheets)
+- [ ] Tilemap loader (Tiled JSON/TMX)
+- [ ] Particle system
+- [ ] Physics integration (Box2D/Chipmunk or custom)
 
 ---
 


### PR DESCRIPTION
## Summary
- clarify engine description and add project roadmap to README
- expand AGENTS guidelines and mark completed roadmap items

## Testing
- `~/dotnet/dotnet build` *(fails: workloads maui-android missing)*

------
https://chatgpt.com/codex/tasks/task_e_689b3cb1b7248332969b6f6ebb796775