### PR TITLE
fix: derive GameView timer period from target frame rate

### DIFF
--- a/MauiGame.Maui/GameView/GameView.cs
+++ b/MauiGame.Maui/GameView/GameView.cs
@@ -107,7 +107,7 @@ public sealed partial class GameView : ContentView
 
     private void StartTimer()
     {
-        Dispatcher.StartTimer(TimeSpan.FromMilliseconds(16), () =>
+        Dispatcher.StartTimer(TimeSpan.FromSeconds(this.fixedDeltaSeconds), () =>
         {
             try
             {


### PR DESCRIPTION
## Summary
- compute GameView timer period from configured frame target instead of fixed 16ms

## Testing
- `dotnet build MauiGame.Core/MauiGame.Core.csproj -v minimal`
- `dotnet msbuild MauiGame.Maui/MauiGame.Maui.csproj /nologo /t:Build /noconlog /flp:logfile=build.log;verbosity=diagnostic` *(fails: NETSDK1147 workloads maui-tizen wasm-tools maui-android required)*

------
https://chatgpt.com/codex/tasks/task_e_689b57dbc6c8833283efbe3a51035b50