### PR TITLE
feat: add optional clear color to renderer begin

### DIFF
--- a/MauiGame.Maui/GameView/SkiaRenderer2D.cs
+++ b/MauiGame.Maui/GameView/SkiaRenderer2D.cs
@@ -14,16 +14,25 @@ public sealed partial class SkiaRenderer2D(SKCanvas canvas) : IRenderer2D, IDisp
     private readonly SKCanvas canvas = canvas ?? throw new ArgumentNullException(nameof(canvas));
     private bool began = false;
 
-    /// <inheritdoc/>
-    public void Begin(in Matrix3x2 transform)
+    /// <summary>
+    /// Begins a 2D batch with an optional camera transform and clear color.
+    /// </summary>
+    /// <param name="transform">Transform matrix applied to subsequent draw calls.</param>
+    /// <param name="clearColor">Optional color to clear the canvas with; if <c>null</c> no clear occurs.</param>
+    public void Begin(in Matrix3x2 transform, SKColor? clearColor = null)
     {
         if (this.began) throw new InvalidOperationException("Begin called twice.");
         this.began = true;
 
         this.canvas.Save();
         this.canvas.SetMatrix(ToSkMatrix(transform));
-        this.canvas.Clear(SKColors.Black);
+        if (clearColor.HasValue)
+        {
+            this.canvas.Clear(clearColor.Value);
+        }
     }
+
+    void IRenderer2D.Begin(in Matrix3x2 transform) => Begin(transform, null);
 
     /// <inheritdoc/>
     public void DrawSprite(ITexture texture, in Vector2 position, in Vector2 origin, in Vector2 scale, float rotationRadians, in RectangleF? sourceRect)

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ public sealed class MyGame : IGame
     {
         var skCtx = (SkiaDrawContext)context;
         using var renderer = new SkiaRenderer2D(skCtx.Canvas);
-        renderer.Begin(Matrix3x2.Identity);
+        renderer.Begin(Matrix3x2.Identity, SkiaSharp.SKColors.Black);
         renderer.DrawSprite(player, position, new Vector2(16, 16), Vector2.One, 0f, null);
         renderer.End();
     }

--- a/SampleGame/Game/Scenes/GameplayScene.cs
+++ b/SampleGame/Game/Scenes/GameplayScene.cs
@@ -2,6 +2,7 @@
 using MauiGame.Core.Scenes;
 using MauiGame.Core.Time;
 using MauiGame.Maui.GameView;
+using SkiaSharp;
 using System.Numerics;
 
 namespace SampleGame.Game.Scenes;
@@ -55,7 +56,7 @@ public sealed partial class GameplayScene : Scene
         using SkiaRenderer2D renderer = new(sk.Canvas);
 
         System.Numerics.Matrix3x2 camera = System.Numerics.Matrix3x2.Identity;
-        renderer.Begin(camera);
+        renderer.Begin(camera, SKColors.Black);
 
         if (this.player != null)
         {

--- a/SampleGame/Game/Scenes/TitleScene.cs
+++ b/SampleGame/Game/Scenes/TitleScene.cs
@@ -2,6 +2,7 @@
 using MauiGame.Core.Scenes;
 using MauiGame.Core.Time;
 using MauiGame.Maui.GameView;
+using SkiaSharp;
 using System.Numerics;
 
 namespace SampleGame.Game.Scenes;
@@ -66,7 +67,7 @@ public sealed partial class TitleScene(IContent content, IAudio audio, IInput in
         using SkiaRenderer2D renderer = new(sk.Canvas);
 
         System.Numerics.Matrix3x2 camera = System.Numerics.Matrix3x2.Identity;
-        renderer.Begin(camera);
+        renderer.Begin(camera, SKColors.Black);
 
         if (this.font != null)
         {


### PR DESCRIPTION
## Summary
- allow specifying optional clear color in `SkiaRenderer2D.Begin`
- update sample scenes and docs to pass desired background colors

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_689b617084188332b42c69bc791a049b