### PR TITLE
fix: add logging for swallowed exceptions

### DIFF
--- a/MauiGame.Core/Utilities/DisposableCollection.cs
+++ b/MauiGame.Core/Utilities/DisposableCollection.cs
@@ -1,4 +1,6 @@
-﻿namespace MauiGame.Core.Utilities;
+using Microsoft.Extensions.Logging;
+
+namespace MauiGame.Core.Utilities;
 
 /// <summary>
 /// Helper that aggregates disposables and disposes them together.
@@ -6,12 +8,14 @@
 public sealed class DisposableCollection : IDisposable
 {
     private readonly List<IDisposable> items;
+    private readonly ILogger logger;
     private bool disposed;
 
     /// <summary>Creates an empty disposable collection.</summary>
-    public DisposableCollection()
+    public DisposableCollection(ILogger? logger = null)
     {
         this.items = [];
+        this.logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance;
         this.disposed = false;
     }
 
@@ -40,12 +44,13 @@ public sealed class DisposableCollection : IDisposable
             {
                 this.items[i].Dispose();
             }
-            catch
+            catch (Exception ex)
             {
-                // Intentionally swallow exceptions from Dispose.
+                this.logger.LogError(ex, "Error disposing item at index {Index}.", i);
             }
         }
 
         this.items.Clear();
     }
 }
+

--- a/SampleGame/Game/Scenes/TitleScene.cs
+++ b/SampleGame/Game/Scenes/TitleScene.cs
@@ -2,6 +2,7 @@
 using MauiGame.Core.Scenes;
 using MauiGame.Core.Time;
 using MauiGame.Maui.GameView;
+using Microsoft.Extensions.Logging;
 using SkiaSharp;
 using System.Numerics;
 
@@ -10,11 +11,12 @@ namespace SampleGame.Game.Scenes;
 /// <summary>
 /// Very simple title scene: shows text, waits for Space/Tap to start gameplay.
 /// </summary>
-public sealed partial class TitleScene(IContent content, IAudio audio, IInput input) : Scene("Title")
+public sealed partial class TitleScene(IContent content, IAudio audio, IInput input, ILogger<TitleScene>? logger = null) : Scene("Title")
 {
     private readonly IContent content = content ?? throw new ArgumentNullException(nameof(content));
     private readonly IAudio audio = audio ?? throw new ArgumentNullException(nameof(audio));
     private readonly IInput input = input ?? throw new ArgumentNullException(nameof(input));
+    private readonly ILogger<TitleScene> logger = logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger<TitleScene>.Instance;
 
     private MauiGame.Core.Contracts.IFont? font;
     private IAudioClip? click;
@@ -48,8 +50,9 @@ public sealed partial class TitleScene(IContent content, IAudio audio, IInput in
                     instance.Dispose(); // fire-and-forget
                 }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                this.logger.LogError(ex, "Failed to play click sound.");
             }
 
             // Signal to switch scene. Since IScene doesn't manage switching,


### PR DESCRIPTION
## Summary
- add ILogger to DisposableCollection and log errors when disposing items
- log click sound playback failures in TitleScene

## Testing
- `dotnet build` *(fails: Specified argument was out of the range of valid values in TerminalLogger)*

------
https://chatgpt.com/codex/tasks/task_e_689b802b0690833285265ef1e411d30d