### PR TITLE
fix: clamp alpha using Math.Clamp

### DIFF
--- a/MauiGame.Core/Time/GameTime.cs
+++ b/MauiGame.Core/Time/GameTime.cs
@@ -19,8 +19,7 @@ public sealed class GameTime(double totalSeconds = 0.0, double deltaSeconds = 0.
     public void Advance(double fixedDeltaSeconds, double alpha)
     {
         ArgumentOutOfRangeException.ThrowIfLessThan(fixedDeltaSeconds, 0.0);
-        if (alpha < 0.0) alpha = 0.0;
-        if (alpha > 1.0) alpha = 1.0;
+        alpha = Math.Clamp(alpha, 0.0, 1.0);
 
         this.DeltaSeconds = fixedDeltaSeconds;
         this.TotalSeconds += fixedDeltaSeconds;


### PR DESCRIPTION
## Summary
- replace manual alpha clamping with Math.Clamp in GameTime.Advance

## Testing
- `dotnet build` *(fails: System.ArgumentOutOfRangeException in TerminalLogger)*

------
https://chatgpt.com/codex/tasks/task_e_689b8460ca34833296e1947727342226