### PR TITLE
fix: defer click sound disposal until playback completes

### DIFF
--- a/SampleGame/Game/Scenes/TitleScene.cs
+++ b/SampleGame/Game/Scenes/TitleScene.cs
@@ -47,7 +47,19 @@ public sealed partial class TitleScene(IContent content, IAudio audio, IInput in
                 if (this.click != null)
                 {
                     IAudioInstance instance = this.audio.Play(this.click, 1.0f, false, true);
-                    instance.Dispose(); // fire-and-forget
+                    double duration = this.click.DurationSeconds ?? 1.0;
+                    _ = Task.Run(async () =>
+                    {
+                        try
+                        {
+                            await Task.Delay(TimeSpan.FromSeconds(duration)).ConfigureAwait(false);
+                            instance.Dispose();
+                        }
+                        catch (Exception disposeEx)
+                        {
+                            this.logger.LogError(disposeEx, "Failed to dispose click sound.");
+                        }
+                    });
                 }
             }
             catch (Exception ex)


### PR DESCRIPTION
## Summary
- allow title screen click sound to play by disposing after its duration

## Testing
- `dotnet build` *(fails: NETSDK1147 workloads maui-android not installed)*
- `dotnet workload restore` *(attempted; large downloads started but run aborted)*

------
https://chatgpt.com/codex/tasks/task_e_689b87ccaab4833282f6433ed1ac01df