### PR TITLE
fix: simplify keyboard IsDown check

### DIFF
--- a/MauiGame.Core/Contracts/IInput.cs
+++ b/MauiGame.Core/Contracts/IInput.cs
@@ -55,7 +55,7 @@ public readonly struct KeyboardState
     }
 
     /// <summary>Returns whether the key is currently pressed.</summary>
-    public bool IsDown(Key key) => this.pressed != null && this.pressed.Contains(key);
+    public bool IsDown(Key key) => this.pressed.Contains(key);
 }
 
 /// <summary>Represents a snapshot of mouse/pointer state.</summary>


### PR DESCRIPTION
## Summary
- remove redundant null check in `KeyboardState.IsDown`

## Testing
- `dotnet build MauiGame.Core/MauiGame.Core.csproj`
- `dotnet build` *(fails: InternalLoggerException)*

------
https://chatgpt.com/codex/tasks/task_e_689b8baec9488332b55dcea049c4a99b