### PR TITLE
docs: clarify resource disposal in audio and content services

### DIFF
--- a/MauiGame.Maui/Content/ContentManager.cs
+++ b/MauiGame.Maui/Content/ContentManager.cs
@@ -7,6 +7,8 @@ namespace MauiGame.Maui.Content;
 
 /// <summary>
 /// Loads textures and fonts from the MAUI packaged application assets.
+/// Caches loaded resources and returns shared instances on subsequent requests.
+/// The manager owns the cached resources and disposes them when <see cref="Dispose"/> is called.
 /// </summary>
 public sealed partial class ContentManager : IContent
 {
@@ -21,6 +23,7 @@ public sealed partial class ContentManager : IContent
     }
 
     /// <inheritdoc/>
+    /// <remarks>Returns a cached texture if available. Callers must not dispose the returned texture.</remarks>
     public async Task<ITexture> LoadTextureAsync(string path, CancellationToken cancellationToken)
     {
         try
@@ -48,6 +51,7 @@ public sealed partial class ContentManager : IContent
     }
 
     /// <inheritdoc/>
+    /// <remarks>Returns a cached font if available. Callers must not dispose the returned font.</remarks>
     public async Task<Core.Contracts.IFont> LoadFontAsync(string path, CancellationToken cancellationToken)
     {
         try
@@ -77,6 +81,7 @@ public sealed partial class ContentManager : IContent
     }
 
     /// <inheritdoc/>
+    /// <remarks>Disposes all cached resources and clears the cache.</remarks>
     public void Dispose()
     {
         foreach (KeyValuePair<string, object> kv in this.cache)


### PR DESCRIPTION
## Summary
- document ownership of streams and players in AudioService clips and instances
- explain ContentManager caching and disposal behavior

## Testing
- `dotnet workload restore --verbosity minimal`
- `dotnet build` *(fails: missing workload packs Microsoft.MacCatalyst.Sdk.net9.0_18.5, Microsoft.iOS.Sdk.net9.0_18.5)*

------
https://chatgpt.com/codex/tasks/task_e_689b8bcb0aac8332becfdbd3760337f7