### PR TITLE
feat: add base game class for inherited services

### DIFF
--- a/MauiGame.Core/Game.cs
+++ b/MauiGame.Core/Game.cs
@@ -1,0 +1,70 @@
+namespace MauiGame.Core;
+
+using MauiGame.Core.Contracts;
+using MauiGame.Core.Scenes;
+using MauiGame.Core.Time;
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Base game class providing access to core engine services and scene management.
+/// </summary>
+public abstract class Game : IGame
+{
+    /// <summary>Initializes a new instance of the <see cref="Game"/> class.</summary>
+    protected Game()
+    {
+        this.Scenes = new SceneManager(logger: Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance);
+        this.Time = new GameTime();
+    }
+
+    /// <summary>Content loading service.</summary>
+    protected IContent Content { get; private set; } = null!;
+
+    /// <summary>Audio playback service.</summary>
+    protected IAudio Audio { get; private set; } = null!;
+
+    /// <summary>Input polling service.</summary>
+    protected IInput Input { get; private set; } = null!;
+
+    /// <summary>Scene manager for organizing gameplay.</summary>
+    protected SceneManager Scenes { get; }
+
+    /// <summary>Time tracking for the game.</summary>
+    protected GameTime Time { get; }
+
+    /// <summary>Wires engine services; called by the host.</summary>
+    /// <param name="content">Content loading service.</param>
+    /// <param name="audio">Audio playback service.</param>
+    /// <param name="input">Input polling service.</param>
+    public void AttachServices(IContent content, IAudio audio, IInput input)
+    {
+        this.Content = content ?? throw new ArgumentNullException(nameof(content));
+        this.Audio = audio ?? throw new ArgumentNullException(nameof(audio));
+        this.Input = input ?? throw new ArgumentNullException(nameof(input));
+    }
+
+    /// <inheritdoc />
+    public virtual void Initialize()
+    {
+    }
+
+    /// <inheritdoc />
+    public virtual async Task LoadAsync(CancellationToken cancellationToken)
+    {
+        await this.Scenes.EnsureLoadedAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public virtual void Update(double deltaSeconds)
+    {
+        this.Time.Advance(deltaSeconds, 0.0);
+        this.Scenes.Update(this.Time);
+    }
+
+    /// <inheritdoc />
+    public virtual void Draw(IDrawContext context)
+    {
+        this.Scenes.Draw(context);
+    }
+}
+

--- a/MauiGame.Maui/GameView/GamePage.cs
+++ b/MauiGame.Maui/GameView/GamePage.cs
@@ -33,15 +33,15 @@ public sealed partial class GamePage : ContentPage, IDisposable
     private bool disposed;
 
     /// <summary>Create a new GamePage driven at the configured target FPS.</summary>
-    /// <param name="gameFactory">Factory used to create the game instance.</param>
+    /// <param name="game">Game instance to run.</param>
     /// <param name="logger">Logger used for reporting errors and warnings.</param>
     /// <param name="options">Engine configuration options.</param>
     public GamePage(
-        Func<IContent, IAudio, IInput, IGame> gameFactory,
+        IGame game,
         ILogger<GamePage> logger,
         MauiGameOptions options)
     {
-        ArgumentNullException.ThrowIfNull(gameFactory);
+        ArgumentNullException.ThrowIfNull(game);
         ArgumentNullException.ThrowIfNull(logger);
         ArgumentNullException.ThrowIfNull(options);
 
@@ -76,7 +76,6 @@ public sealed partial class GamePage : ContentPage, IDisposable
         registry.AddService<IContent>(content);
         registry.AddService<IAudio>(audio);
 
-        IGame game = gameFactory(content, audio, this.input);
         this.host = new GameHost(game, registry);
 
         // Wire up input

--- a/MauiGame.Maui/Hosting/GameHost.cs
+++ b/MauiGame.Maui/Hosting/GameHost.cs
@@ -1,4 +1,5 @@
-﻿using MauiGame.Core.Contracts;
+using MauiGame.Core;
+using MauiGame.Core.Contracts;
 using MauiGame.Core.Time;
 using MauiGame.Maui.Audio;
 using MauiGame.Maui.Content;
@@ -29,7 +30,6 @@ public sealed partial class GameHost : IDisposable
         this.time = new GameTime();
         this.InterpolationAlpha = 0.0;
 
-        // Ensure defaults
         if (this.services.TryGet<IContent>() == null)
         {
             this.services.AddService<IContent>(new ContentManager());
@@ -41,6 +41,14 @@ public sealed partial class GameHost : IDisposable
         if (this.services.TryGet<IInput>() == null)
         {
             this.services.AddService<IInput>(new InputService());
+        }
+
+        if (this.game is Game coreGame)
+        {
+            IContent content = this.services.Get<IContent>();
+            IAudio audio = this.services.Get<IAudio>();
+            IInput input = this.services.Get<IInput>();
+            coreGame.AttachServices(content, audio, input);
         }
     }
 
@@ -79,8 +87,6 @@ public sealed partial class GameHost : IDisposable
     {
         try
         {
-            // When using Skia backend, construct the per-frame renderer here if the game expects it,
-            // or the game can build its own renderer using the Skia canvas from context.
             this.game.Draw(context);
         }
         catch (Exception ex)
@@ -112,3 +118,4 @@ public sealed partial class GameHost : IDisposable
         }
     }
 }
+

--- a/MauiGame.Maui/Hosting/MauiAppBuilderExtensions.cs
+++ b/MauiGame.Maui/Hosting/MauiAppBuilderExtensions.cs
@@ -27,8 +27,7 @@ public static class MauiAppBuilderExtensions
         builder.UseSkiaSharp();
 
         builder.Services.AddSingleton(options);
-        builder.Services.AddSingleton<Func<IContent, IAudio, IInput, IGame>>(sp => (content, audio, input) =>
-            ActivatorUtilities.CreateInstance<TGame>(sp, content, audio, input));
+        builder.Services.AddSingleton<IGame>(sp => ActivatorUtilities.CreateInstance<TGame>(sp));
         builder.Services.AddSingleton<GamePage>();
 
         return builder;

--- a/README.md
+++ b/README.md
@@ -94,33 +94,35 @@ Set **SampleGame** as the startup project and run it on your preferred platform 
 ## 🛠 Example Usage
 
 ```csharp
-public sealed class MyGame : IGame
+public sealed class MyGame : Game
 {
     private ITexture player;
     private Vector2 position;
 
-    public void Initialize()
+    public override void Initialize()
     {
-        position = new Vector2(100, 100);
+        this.position = new Vector2(100, 100);
     }
 
-    public async Task LoadAsync(CancellationToken token)
+    public override async Task LoadAsync(CancellationToken token)
     {
-        var content = new ContentManager();
-        player = await content.LoadTextureAsync("Assets/player.png", token);
+        this.player = await this.Content.LoadTextureAsync("Assets/player.png", token);
+        await base.LoadAsync(token).ConfigureAwait(false);
     }
 
-    public void Update(double delta)
+    public override void Update(double delta)
     {
-        position.X += 50f * (float)delta;
+        base.Update(delta);
+        this.position.X += 50f * (float)delta;
     }
 
-    public void Draw(IDrawContext context)
+    public override void Draw(IDrawContext context)
     {
-        var skCtx = (SkiaDrawContext)context;
-        using var renderer = new SkiaRenderer2D(skCtx.Canvas);
+        base.Draw(context);
+        SkiaDrawContext skCtx = (SkiaDrawContext)context;
+        using SkiaRenderer2D renderer = new(skCtx.Canvas);
         renderer.Begin(Matrix3x2.Identity, SkiaSharp.SKColors.Black);
-        renderer.DrawSprite(player, position, new Vector2(16, 16), Vector2.One, 0f, null);
+        renderer.DrawSprite(this.player, this.position, new Vector2(16, 16), Vector2.One, 0f, null);
         renderer.End();
     }
 }

--- a/SampleGame/Game/MyGame.cs
+++ b/SampleGame/Game/MyGame.cs
@@ -1,68 +1,46 @@
-﻿using MauiGame.Core.Contracts;
-using MauiGame.Core.Scenes;
-using MauiGame.Core.Time;
+using MauiGame.Core;
+using MauiGame.Core.Contracts;
 using SampleGame.Game.Scenes;
 
 namespace SampleGame.Game;
+
 /// <summary>
 /// The game implementation that manages scenes and shared assets.
 /// </summary>
-public sealed class MyGame(IContent content, IAudio audio, IInput input) : IGame
+public sealed class MyGame : Game
 {
-    private readonly IContent content = content ?? throw new ArgumentNullException(nameof(content));
-    private readonly IAudio audio = audio ?? throw new ArgumentNullException(nameof(audio));
-    private readonly IInput input = input ?? throw new ArgumentNullException(nameof(input));
-    private readonly SceneManager scenes = new(logger: Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance);
     private IAudioClip? bgm;
     private IAudioInstance? bgmInstance;
-    private readonly GameTime time = new();
 
     /// <inheritdoc/>
-    public void Initialize()
+    public override void Initialize()
     {
-        // Start on the title scene
-        TitleScene title = new(this.content, this.audio, this.input);
+        TitleScene title = new(this.Content, this.Audio, this.Input);
         title.OnStartRequested += async () =>
         {
             try { await StartGameplayAsync(CancellationToken.None).ConfigureAwait(false); } catch (Exception) { }
         };
-        this.scenes.Push(title);
+        this.Scenes.Push(title);
     }
 
     /// <inheritdoc/>
-    public async Task LoadAsync(CancellationToken cancellationToken)
+    public override async Task LoadAsync(CancellationToken cancellationToken)
     {
-        // Preload global audio (bgm).
-        this.bgm = await this.audio.LoadClipAsync("Audio/bgm_loop.mp3", cancellationToken).ConfigureAwait(false);
+        this.bgm = await this.Audio.LoadClipAsync("Audio/bgm_loop.mp3", cancellationToken).ConfigureAwait(false);
+        await base.LoadAsync(cancellationToken).ConfigureAwait(false);
 
-        // Ensure current scene is loaded.
-        await this.scenes.EnsureLoadedAsync(cancellationToken).ConfigureAwait(false);
-
-        // Start BGM.
         if (this.bgm != null)
         {
-            this.bgmInstance = this.audio.Play(this.bgm, volume: 0.5f, loop: true, autoStart: true);
+            this.bgmInstance = this.Audio.Play(this.bgm, volume: 0.5f, loop: true, autoStart: true);
         }
-    }
-
-    /// <inheritdoc/>
-    public void Update(double deltaSeconds)
-    {
-        this.time.Advance(deltaSeconds, 0.0);
-        this.scenes.Update(this.time);
-    }
-
-    /// <inheritdoc/>
-    public void Draw(IDrawContext context)
-    {
-        this.scenes.Draw(context);
     }
 
     /// <summary>Transitions from title to gameplay.</summary>
     public async Task StartGameplayAsync(CancellationToken cancellationToken)
     {
-        GameplayScene gameplay = new(this.content, this.audio, this.input);
-        this.scenes.Replace(gameplay);
-        await this.scenes.EnsureLoadedAsync(cancellationToken).ConfigureAwait(false);
+        GameplayScene gameplay = new(this.Content, this.Audio, this.Input);
+        this.Scenes.Replace(gameplay);
+        await this.Scenes.EnsureLoadedAsync(cancellationToken).ConfigureAwait(false);
     }
 }
+


### PR DESCRIPTION
## Summary
- add core `Game` base class exposing content, audio, input, scenes, and time
- update hosting to attach services and simplify DI setup
- simplify sample game and docs to use inherited services

## Testing
- `dotnet workload restore` *(fails: large output but attempted)*
- `dotnet build` *(fails: project depends on workloads like MacCatalyst/iOS not installed)*

------
https://chatgpt.com/codex/tasks/task_e_689bdba45f508332bb5165ba4d9a6244